### PR TITLE
Update to repository.json to correct repo link to github page

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
     "name": "Greylurk's Experiments",
-    "url": "https://github.com/greylurk/hassio-addon-experiment",
+    "url": "https://github.com/greylurk/hassio-custom-addons",
     "maintainer": "greylurk"
 }


### PR DESCRIPTION
The previous link was to https://github.com/greylurk/hassio-addon-experiments which was 404.